### PR TITLE
Use file output option instead of redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This test shouldn't take more than 60 minutes (even with the bonus section). If 
 Please do not fork this repo on github or open a pull request. Submit your solution via email in an archive, which can be created with the following git command:
 
 ```
-git archive HEAD . > solution.tar
+git archive HEAD . -o solution.tar
 ```
 
 To run this test type:


### PR DESCRIPTION
Windows console tends to mess up the character sets, resulting in broken .tar files. This option tells git to directly write to the file instead of redirecting stdout